### PR TITLE
Created keep_awake_async.cljs, activateKeepAwake deprecated.

### DIFF
--- a/src/main/shadow/expo/keep_awake_async.cljs
+++ b/src/main/shadow/expo/keep_awake_async.cljs
@@ -1,0 +1,4 @@
+(ns ^:dev/once shadow.expo.keep-awake-async
+  (:require ["expo-keep-awake" :refer [activateKeepAwakeAsync]]))
+
+(activateKeepAwakeAsync)


### PR DESCRIPTION
activateKeepAwake (AKA) was deprecated a while back in favor of activateKeepAwakeAsync (AKAA). 

AKA appears to work just fine, but when you're developing in the Expo Go app those warnings are proper annoying. Using AKAA fixes the warnings.

I propose making another namespace 'shadow.expo.keep-awake-async instead of changing 'shadow.expo.keep-awake because the expo dev story is not without complications in CLJS and I suspect some shadow users may still be relying on versions of KeepAwake that do not have the async function.